### PR TITLE
Simple Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.12-slim
+
+# Install system deps for Node.js and general utils
+RUN apt-get update && apt-get install -y \
+    curl \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry globally
+RUN curl -sSL https://install.python-poetry.org | python3 -
+
+# Add Poetry to PATH
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Install Claude Code CLI globally (for SDK compatibility)
+RUN npm install -g @anthropic-ai/claude-code
+
+# Copy the app code
+COPY . /app
+
+# Set working directory
+WORKDIR /app
+
+# Install Python dependencies with Poetry
+RUN poetry install --no-root
+
+# Expose the port (default 8000)
+EXPOSE 8000
+
+# Run the app with Uvicorn (development mode with reload; switch to --no-reload for prod)
+CMD ["poetry", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  claude-wrapper:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ~/.claude:/root/.claude
+    environment:
+      - PORT=8000


### PR DESCRIPTION
This PR introduces Docker support to the Claude Code OpenAI Wrapper, enabling users to run the API server in an isolated, portable container. This is particularly useful for development, testing, and production deployments, as it bundles all dependencies (Python, Node.js, Poetry, and the Claude Code SDK) without polluting the host environment.

### Key Changes:
- **Dockerfile**: Added in the root for building a slim Python 3.12-based image with necessary deps.
- **docker-compose.yml** (optional): Included for easier local runs with volumes and env vars.
- **README.md Update**: Appended a comprehensive "Docker Setup" section with build/run instructions, custom configs, remote deployment, and troubleshooting.

### Motivation:
- Simplifies setup for users who prefer containers.
- Supports subscription auth (e.g., Claude Max) via volume-mounted tokens.
- Enhances portability for remote/cloud deployments (e.g., AWS, Google Cloud).

### How to Test:
1. Build: `docker build -t claude-wrapper:latest .`
2. Run: Use the production or dev command from the guide.
3. Verify: Curl endpoints like `http://localhost:8000/v1/models` and test a completion request.

No breaking changes; this is additive. Feedback welcome!