### PR TITLE
Fix: Update Quick Start command to use src.main:app

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cd claude-code-openai-wrapper
 poetry install
 
 # 4. Start the server
-poetry run uvicorn main:app --reload --port 8000
+poetry run uvicorn src.main:app --reload --port 8000
 
 # 5. Test it works
 poetry run python test_endpoints.py
@@ -287,7 +287,7 @@ RATE_LIMIT_HEALTH_PER_MINUTE=30
 
    **Development mode (recommended - auto-reloads on changes):**
    ```bash
-   poetry run uvicorn main:app --reload --port 8000
+   poetry run uvicorn src.main:app --reload --port 8000
    ```
 
    **Production mode:**

--- a/docs/MIGRATION_STATUS.md
+++ b/docs/MIGRATION_STATUS.md
@@ -94,7 +94,7 @@ git clone https://github.com/RichardAtCT/claude-code-openai-wrapper
 cd claude-code-openai-wrapper
 git checkout claude/research-api-updates-011CUjNxYatBANZZq6bssaxN
 poetry install
-poetry run uvicorn main:app --host 0.0.0.0 --port 8000
+poetry run uvicorn src.main:app --host 0.0.0.0 --port 8000
 ```
 
 ### Verification


### PR DESCRIPTION
Fixes issue #22 where Quick Start commands were outdated after moving main to src/.

** Changes:**
- Updated README.md Quick Start section to use `src.main:app` instead of `main:app`
- Fixed both occurrences on lines 88 and 290
- Updated MIGRATION_STATUS.md to match the correct path

Generated with [Claude Code](https://claude.ai/code)