### PR TITLE
feat: add Claude 4.6 models and fix OpenClaw 422 validation errors

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -69,9 +69,12 @@ DEFAULT_DISALLOWED_TOOLS = [
 # Models supported by Claude Agent SDK (as of November 2025)
 # NOTE: Claude Agent SDK only supports Claude 4+ models, not Claude 3.x
 CLAUDE_MODELS = [
-    # Claude 4.5 Family (Latest - Fall 2025) - RECOMMENDED
-    "claude-opus-4-5-20250929",  # Latest Opus 4.5 - Most capable
-    "claude-sonnet-4-5-20250929",  # Recommended - best coding model
+    # Claude 4.6 Family (Latest) - RECOMMENDED
+    "claude-opus-4-6",      # Most capable
+    "claude-sonnet-4-6",    # Recommended - best coding model
+    # Claude 4.5 Family (Fall 2025)
+    "claude-opus-4-5-20250929",
+    "claude-sonnet-4-5-20250929",
     "claude-haiku-4-5-20251001",  # Fast & cheap
     # Claude 4.1
     "claude-opus-4-1-20250805",  # Upgraded Opus 4
@@ -88,7 +91,7 @@ CLAUDE_MODELS = [
 
 # Default model (recommended for most use cases)
 # Can be overridden via DEFAULT_MODEL environment variable
-DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "claude-sonnet-4-5-20250929")
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "claude-sonnet-4-6")
 
 # Fast model (for speed/cost optimization)
 FAST_MODEL = "claude-haiku-4-5-20251001"

--- a/src/models.py
+++ b/src/models.py
@@ -18,26 +18,44 @@ def get_default_model():
 class ContentPart(BaseModel):
     """Content part for multimodal messages (OpenAI format)."""
 
-    type: Literal["text"]
-    text: str
+    type: str
+    text: Optional[str] = None
+
+    model_config = {"extra": "ignore"}
 
 
 class Message(BaseModel):
-    role: Literal["system", "user", "assistant"]
-    content: Union[str, List[ContentPart]]
+    role: Literal["system", "user", "assistant", "tool"]
+    content: Optional[Union[str, List[Any]]] = None
     name: Optional[str] = None
+
+    model_config = {"extra": "ignore"}
 
     @model_validator(mode="after")
     def normalize_content(self):
         """Convert array content to string for Claude Code compatibility."""
+        if self.content is None:
+            self.content = ""
+            return self
+
         if isinstance(self.content, list):
             # Extract text from content parts and concatenate
             text_parts = []
             for part in self.content:
-                if isinstance(part, ContentPart) and part.type == "text":
+                if isinstance(part, ContentPart) and part.text:
                     text_parts.append(part.text)
-                elif isinstance(part, dict) and part.get("type") == "text":
-                    text_parts.append(part.get("text", ""))
+                elif isinstance(part, dict):
+                    if part.get("type") == "text" and part.get("text"):
+                        text_parts.append(part["text"])
+                    elif part.get("type") == "tool_result":
+                        # Extract text from tool result content
+                        inner = part.get("content", "")
+                        if isinstance(inner, str):
+                            text_parts.append(inner)
+                        elif isinstance(inner, list):
+                            for block in inner:
+                                if isinstance(block, dict) and block.get("text"):
+                                    text_parts.append(block["text"])
 
             # Join all text parts with newlines
             self.content = "\n".join(text_parts) if text_parts else ""


### PR DESCRIPTION
## Summary

- Add `claude-sonnet-4-6` and `claude-opus-4-6` to `CLAUDE_MODELS` and set `claude-sonnet-4-6` as the new `DEFAULT_MODEL`
- Fix 422 validation errors when using OpenClaw as a client by accepting `role: 'tool'` messages, `null` content, and arbitrary content block types
- Add `model_config extra='ignore'` to silently drop unknown fields (e.g. `store`, `service_tier`) sent by OpenClaw

## Changes

### `src/constants.py`
- Added Claude 4.6 models (`claude-sonnet-4-6`, `claude-opus-4-6`) at the top of `CLAUDE_MODELS`
- Updated `DEFAULT_MODEL` from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6`

### `src/models.py`
- `Message.role`: added `"tool"` to allowed roles — OpenClaw sends tool result messages with `role: "tool"`
- `Message.content`: changed to `Optional[Union[str, List[Any]]]` to handle `null` content (assistant messages mid-tool-call) and arbitrary content block arrays
- `ContentPart`: loosened `type` from `Literal["text"]` to `str` and made `text` optional to handle non-text block types (tool_use, tool_result, image, etc.)
- `normalize_content`: added null handling and text extraction from `tool_result` content blocks
- Added `model_config = {"extra": "ignore"}` to both `ContentPart` and `Message` to silently drop unknown fields

## Test plan

- [x] All existing tests pass: `poetry run python tests/test_endpoints.py` → 4/4
- [x] All existing tests pass: `poetry run python tests/test_basic.py` → 4/4
- [x] Server starts cleanly with `poetry run uvicorn src.main:app --reload --port 8000`
- [x] Verify OpenClaw requests no longer return 422 with a live OpenClaw instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)