### PR TITLE
feat: add Claude 4.6 models and update default model

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -69,7 +69,10 @@ DEFAULT_DISALLOWED_TOOLS = [
 # Models supported by Claude Agent SDK (as of November 2025)
 # NOTE: Claude Agent SDK only supports Claude 4+ models, not Claude 3.x
 CLAUDE_MODELS = [
-    # Claude 4.5 Family (Latest - Fall 2025) - RECOMMENDED
+    # Claude 4.6 Family (Latest) - RECOMMENDED
+    "claude-opus-4-6",      # Most capable
+    "claude-sonnet-4-6",    # Recommended - best coding model
+    # Claude 4.5 Family (Fall 2025)
     "claude-opus-4-5-20250929",  # Latest Opus 4.5 - Most capable
     "claude-sonnet-4-5-20250929",  # Recommended - best coding model
     "claude-haiku-4-5-20251001",  # Fast & cheap
@@ -88,7 +91,7 @@ CLAUDE_MODELS = [
 
 # Default model (recommended for most use cases)
 # Can be overridden via DEFAULT_MODEL environment variable
-DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "claude-sonnet-4-5-20250929")
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "claude-sonnet-4-6")
 
 # Fast model (for speed/cost optimization)
 FAST_MODEL = "claude-haiku-4-5-20251001"


### PR DESCRIPTION
## Summary

- Add `claude-sonnet-4-6` and `claude-opus-4-6` to `CLAUDE_MODELS`
- Set `claude-sonnet-4-6` as the new `DEFAULT_MODEL` (overridable via `DEFAULT_MODEL` env var)

## Changes

### `src/constants.py`
- Added a new **Claude 4.6 Family** section at the top of `CLAUDE_MODELS` with `claude-opus-4-6` and `claude-sonnet-4-6`
- Updated `DEFAULT_MODEL` from `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`

## Test plan

- [x] `poetry run python tests/test_endpoints.py` → 4/4 passed
- [x] `poetry run python tests/test_basic.py` → 4/4 passed
- [x] `/v1/models` endpoint returns 8 models with 4.6 models at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)