### PR TITLE
fix: handle OpenClaw message format to resolve 422 validation errors

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -18,26 +18,44 @@ def get_default_model():
 class ContentPart(BaseModel):
     """Content part for multimodal messages (OpenAI format)."""
 
-    type: Literal["text"]
-    text: str
+    type: str
+    text: Optional[str] = None
+
+    model_config = {"extra": "ignore"}
 
 
 class Message(BaseModel):
-    role: Literal["system", "user", "assistant"]
-    content: Union[str, List[ContentPart]]
+    role: Literal["system", "user", "assistant", "tool"]
+    content: Optional[Union[str, List[Any]]] = None
     name: Optional[str] = None
+
+    model_config = {"extra": "ignore"}
 
     @model_validator(mode="after")
     def normalize_content(self):
         """Convert array content to string for Claude Code compatibility."""
+        if self.content is None:
+            self.content = ""
+            return self
+
         if isinstance(self.content, list):
             # Extract text from content parts and concatenate
             text_parts = []
             for part in self.content:
-                if isinstance(part, ContentPart) and part.type == "text":
+                if isinstance(part, ContentPart) and part.text:
                     text_parts.append(part.text)
-                elif isinstance(part, dict) and part.get("type") == "text":
-                    text_parts.append(part.get("text", ""))
+                elif isinstance(part, dict):
+                    if part.get("type") == "text" and part.get("text"):
+                        text_parts.append(part["text"])
+                    elif part.get("type") == "tool_result":
+                        # Extract text from tool result content
+                        inner = part.get("content", "")
+                        if isinstance(inner, str):
+                            text_parts.append(inner)
+                        elif isinstance(inner, list):
+                            for block in inner:
+                                if isinstance(block, dict) and block.get("text"):
+                                    text_parts.append(block["text"])
 
             # Join all text parts with newlines
             self.content = "\n".join(text_parts) if text_parts else ""


### PR DESCRIPTION
## Summary

OpenClaw sends message formats that go beyond the strict OpenAI Chat Completions spec the wrapper previously enforced, resulting in `422 Unprocessable Content` errors. This PR makes the `Message` and `ContentPart` models tolerant of those formats while preserving existing behaviour for standard OpenAI clients.

## Root cause

OpenClaw (and other agentic clients) send:
- Messages with `role: "tool"` — tool call result messages returned to the model
- Messages with `content: null` — assistant messages that made a tool call and have no text content yet
- Content arrays containing non-text block types (e.g. `tool_use`, `tool_result`, `image`)
- Extra top-level fields such as `store` or `service_tier` from the OpenAI Responses API

## Changes

### `src/models.py`

| Field | Before | After |
|---|---|---|
| `Message.role` | `Literal["system", "user", "assistant"]` | `Literal["system", "user", "assistant", "tool"]` |
| `Message.content` | `Union[str, List[ContentPart]]` | `Optional[Union[str, List[Any]]]` |
| `ContentPart.type` | `Literal["text"]` | `str` |
| `ContentPart.text` | `str` (required) | `Optional[str]` |
| Unknown fields | error | silently ignored (`extra="ignore"`) |

- `normalize_content` now handles `None` content (returns `""`) and extracts text from `tool_result` content blocks
- `model_config = {"extra": "ignore"}` added to both `ContentPart` and `Message`

## Test plan

- [x] `poetry run python tests/test_endpoints.py` → 4/4 passed
- [x] `poetry run python tests/test_basic.py` → 4/4 passed
- [x] No regression for standard OpenAI SDK requests
- [x] Verify OpenClaw requests no longer return 422 with a live OpenClaw instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)