### PR TITLE
🦭 fix: add SELinux :Z label to .claude volume mount (Docker & Podman)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ~/.claude:/root/.claude
+      - ~/.claude:/root/.claude:Z
       # Optional: Mount a specific workspace directory
       # Uncomment and modify the line below to use a custom workspace
       # - ./workspace:/workspace


### PR DESCRIPTION
## Summary
- Adds `:Z` SELinux label to the `.claude` volume mount in `docker-compose.yml`
- Fixes `Permission denied` errors on SELinux-enabled systems (Fedora, RHEL) and rootless Podman
- Safely ignored on systems without SELinux — no impact on plain Docker

## Test plan
- [ ] Verify container starts on rootless Podman (Fedora/RHEL)
- [ ] Verify container still works on plain Docker (no SELinux)
- [ ] Verify `.claude` directory is readable inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)