### PR TITLE
feat: add CLAUDE_CODE_OAUTH_TOKEN support for subscription auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,10 @@ CORS_ORIGINS=["*"]
 # fallback list.
 # ANTHROPIC_API_KEY=sk-ant-...
 
+# OAuth token for Claude Code subscription auth (CLI login).
+# Use this instead of ANTHROPIC_API_KEY if you authenticate via `claude auth`.
+# CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+
 # Pin the advertised model list. Takes precedence over both live and static.
 # CLAUDE_MODELS_OVERRIDE=claude-sonnet-4-6,claude-opus-4-6
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       # - ./workspace:/workspace
     environment:
       - PORT=8000
+      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}
       # Optional: Set Claude's working directory (defaults to isolated temp dir)
       # Uncomment and modify the line below to set a custom working directory
       # - CLAUDE_CWD=/workspace


### PR DESCRIPTION
## Summary
- Passes `CLAUDE_CODE_OAUTH_TOKEN` env var through `docker-compose.yml` so subscription users can authenticate without an API key
- Documents the new variable in `.env.example` with usage instructions
- Enables users who authenticate via `claude auth` (CLI login) to use the wrapper in Docker/Podman

## Test plan
- [ ] Set `CLAUDE_CODE_OAUTH_TOKEN` in `.env` and verify wrapper authenticates successfully
- [ ] Verify wrapper still works with `ANTHROPIC_API_KEY` (no regression)
- [ ] Verify container starts without either token set (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)